### PR TITLE
eventcomment3

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -1,1 +1,12 @@
 from django.db import models
+
+
+# Define comment class and other neccesssary fields
+class Comment(models.Model):
+    event = models.ForeignKey('Event', on_delete=models.CASCADE)
+    content = models.TextField()
+    timestamp = models.DateTimeField(auto_now_add=True)
+    user = models.ForeignKey('User', on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.content

--- a/events/serializers.py
+++ b/events/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers 
+from .models import Comment
+
+class CommentSerialzer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ('content', 'timestamp' 'user')

--- a/events/views.py
+++ b/events/views.py
@@ -1,3 +1,19 @@
 from django.shortcuts import render
 
 # Create your views here.
+from rest_framework import viewsets
+from .models import Comment
+from groups.models import GroupEvents
+from .serializers import CommentSerialzer
+
+
+class CommentViewSet(viewsets.ModelViewSet):
+    serializer = CommentSerialzer
+
+    def queryset(self):
+        event_id = self.kwargs['eventId']
+        try:
+            event = GroupEvents.objects.get(event_id=event_id)
+            return Comment.objects.filter(event=event)
+        except GroupEvents.DoesNotExist:
+            return Comment.objects.none()

--- a/groups/urls.py
+++ b/groups/urls.py
@@ -1,11 +1,13 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import GroupViewSet, UserGroupsViewSet, GroupEventsViewSet
+from events.views import CommentViewSet
 
 router = DefaultRouter()
 router.register(r'groups', GroupViewSet)
 router.register(r'usergroups', UserGroupsViewSet)
 router.register(r'groupevents', GroupEventsViewSet)
+router.register(r'groupevents/(?P<event_id>[^/.]+)/comments', CommentViewSet, basename='comment')
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
Implemented an API endpoints that allows users to retrieve comments associated with a specific event

GET /api/events/:eventId/comments: Get comments for an event
POST /api/comments/:commentId/images: Add an image to a comment
GET /api/comments/:commentId/images: Get images for a comment

with the following Acceptance Criteria:
A new API endpoint (GET /api/events/:eventId/comments) for fetching comments for an event.
Accept the unique event identifier (eventId) as a URL parameter.
Retrieve all comments associated with the specified event from the database.
Return an appropriate response with a list of comments, including their content, creation timestamp, and user information.
Handle cases where the requested eventId does not exist and return an error response with an appropriate status code (e.g., 404 Not Found).

please reach out to me asap for any modification, my head aches abeg