### PR TITLE
Feat: GitHub Action workflow

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,0 +1,54 @@
+name: Event App API Github Action Workflow
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/*'
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version: [3.11.0]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set Python Version ${{ matrix.python-version }}
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      # - name: Lint with flake8
+      #   run: |
+      #     flake8 .
+      - name: Run migrations
+        run: |
+          python manage.py migrate
+      # - name: Runing the tests
+      #   run: |
+      #     python manage.py test
+  
+  deploy:
+    runs-on: ubuntu-latest
+    name: deploy our django application to digital ocean
+    needs: [build]
+    steps:
+       - name: Checkout code
+         uses: actions/checkout@v2
+
+       - name: DigitalOcean App Platform deployment
+         uses: digitalocean/app_action@v1.1.5
+         with:
+            app_name: event-app-api
+            token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+            # branch: "master"


### PR DESCRIPTION
**Description:**
This pull request adds a GitHub Action workflow to automate the Continuous Integration (CI) and Continuous Deployment (CD) process for our Event App API project. The workflow includes linting, testing, and deployment steps.

**Motivation and Context:**
**DestinedCodes** requested for this feat. he said stuff like _"Any other team here using GitHub actions????
Omor the organization account has run out of free 2000 minutes provided for a free tier.
I'd love to have those actions up and running so that we don't risk merging a code that'll cause regression"_

**Changes Made:**
- Added a `.github/workflows` directory to the repository.
- Created a YAML file for the GitHub Action workflow.
- Configured the workflow to run on pushes and merges to the main branch.
- Included steps for linting with Flake8, running Django tests, and deploying to Digital Ocean.
- Added necessary environment variables and secrets.

**Testing Done:**
- Tested the workflow locally to ensure it works as expected.
- Triggered the workflow on a test branch and verified that it performed the defined tasks correctly.

**Screenshots/GIFs:**
<img src="https://res.cloudinary.com/dkezlmzn1/image/upload/v1695284057/Screenshot_2023-09-21_at_9.10.50_AM_ey8uxb.png"/>
<img src="https://res.cloudinary.com/dkezlmzn1/image/upload/v1695284057/Screenshot_2023-09-21_at_9.11.06_AM_omalwe.png"/>

**Known Limitations:**
Lint with flake8 and Running of tests are currently commented out.

**Checklist:**
- [x] The workflow runs successfully.
- [x] Code follows the project's coding standards

**Request Review**

Please review this pull request and provide feedback. Once approved, we can merge it to automate our CI/CD process, making our development workflow more efficient and reliable. I'd also need admin access to the repo in other for me to link it to my Digital Ocean account and configure the Digital Ocean ACCESS TOKEN.